### PR TITLE
chore: Update bundleHelm.yaml, bump Login-Action to V3

### DIFF
--- a/.github/workflows/bundleHelm.yaml
+++ b/.github/workflows/bundleHelm.yaml
@@ -39,7 +39,7 @@ jobs:
           helm package --dependency-update ./bitnami_charts/bitnami/external-dns --destination dist
       - name: Login to GHCR
         if: github.event_name != 'pull_request'
-        uses: docker/login-action@v1
+        uses: docker/login-action@v3
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}


### PR DESCRIPTION
The `save-state` command is deprecated and will be disabled soon. -> https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/